### PR TITLE
Resource Group Cleaners are now conditionally run

### DIFF
--- a/dalek/cleaners/resource_group_data_protection.go
+++ b/dalek/cleaners/resource_group_data_protection.go
@@ -83,3 +83,9 @@ func (removeDataProtectionFromResourceGroupCleaner) Cleanup(ctx context.Context,
 
 	return nil
 }
+
+func (removeDataProtectionFromResourceGroupCleaner) ResourceTypes() []string {
+	return []string{
+		"Microsoft.DataProtection/backupVaults",
+	}
+}

--- a/dalek/cleaners/resource_group_lock.go
+++ b/dalek/cleaners/resource_group_lock.go
@@ -15,11 +15,11 @@ var _ ResourceGroupCleaner = removeLocksFromResourceGroupCleaner{}
 type removeLocksFromResourceGroupCleaner struct {
 }
 
-func (r removeLocksFromResourceGroupCleaner) Name() string {
+func (removeLocksFromResourceGroupCleaner) Name() string {
 	return "Removing Locks.."
 }
 
-func (r removeLocksFromResourceGroupCleaner) Cleanup(ctx context.Context, id commonids.ResourceGroupId, client *clients.AzureClient, opts options.Options) error {
+func (removeLocksFromResourceGroupCleaner) Cleanup(ctx context.Context, id commonids.ResourceGroupId, client *clients.AzureClient, opts options.Options) error {
 	locks, err := client.ResourceManager.LocksClient.ListAtResourceGroupLevel(ctx, id, managementlocks.DefaultListAtResourceGroupLevelOperationOptions())
 	if err != nil {
 		log.Printf("[DEBUG] Error obtaining Resource Group Locks : %+v", err)
@@ -50,4 +50,10 @@ func (r removeLocksFromResourceGroupCleaner) Cleanup(ctx context.Context, id com
 		}
 	}
 	return nil
+}
+
+func (removeLocksFromResourceGroupCleaner) ResourceTypes() []string {
+	return []string{
+		"Microsoft.Authorization/locks",
+	}
 }

--- a/dalek/cleaners/resource_group_palo_alto_local_rulestack.go
+++ b/dalek/cleaners/resource_group_palo_alto_local_rulestack.go
@@ -21,11 +21,11 @@ type paloAltoLocalRulestackCleaner struct{}
 
 var _ ResourceGroupCleaner = paloAltoLocalRulestackCleaner{}
 
-func (p paloAltoLocalRulestackCleaner) Name() string {
+func (paloAltoLocalRulestackCleaner) Name() string {
 	return "Removing Rulestack Rules"
 }
 
-func (p paloAltoLocalRulestackCleaner) Cleanup(ctx context.Context, id commonids.ResourceGroupId, client *clients.AzureClient, opts options.Options) error {
+func (paloAltoLocalRulestackCleaner) Cleanup(ctx context.Context, id commonids.ResourceGroupId, client *clients.AzureClient, opts options.Options) error {
 	rulestacksClient := client.ResourceManager.PaloAlto.LocalRulestacks
 
 	rulestacks, err := rulestacksClient.ListByResourceGroupComplete(ctx, id)
@@ -158,4 +158,21 @@ func (p paloAltoLocalRulestackCleaner) Cleanup(ctx context.Context, id commonids
 	}
 
 	return nil
+}
+
+func (paloAltoLocalRulestackCleaner) ResourceTypes() []string {
+	return []string{
+		"PaloAltoNetworks.Cloudngfw/firewalls",
+		"PaloAltoNetworks.Cloudngfw/localRulestacks",
+		"PaloAltoNetworks.Cloudngfw/localRulestacks/certificates",
+		"PaloAltoNetworks.Cloudngfw/localRulestacks/fqdnLists",
+		"PaloAltoNetworks.Cloudngfw/localRulestacks/localRules",
+		"PaloAltoNetworks.Cloudngfw/localRulestacks/prefixLists",
+		"PaloAltoNetworks.Cloudngfw/globalRulestacks",
+		"PaloAltoNetworks.Cloudngfw/globalRulestacks/certificates",
+		"PaloAltoNetworks.Cloudngfw/globalRulestacks/fqdnLists",
+		"PaloAltoNetworks.Cloudngfw/globalRulestacks/postRules",
+		"PaloAltoNetworks.Cloudngfw/globalRulestacks/preRules",
+		"PaloAltoNetworks.Cloudngfw/globalRulestacks/prefixLists",
+	}
 }

--- a/dalek/cleaners/resource_group_servicebus_namespace_break_pairing.go
+++ b/dalek/cleaners/resource_group_servicebus_namespace_break_pairing.go
@@ -20,11 +20,11 @@ var _ ResourceGroupCleaner = serviceBusNamespaceBreakPairingCleaner{}
 type serviceBusNamespaceBreakPairingCleaner struct {
 }
 
-func (s serviceBusNamespaceBreakPairingCleaner) Name() string {
+func (serviceBusNamespaceBreakPairingCleaner) Name() string {
 	return "ServiceBus Namespace - Break Pairing"
 }
 
-func (s serviceBusNamespaceBreakPairingCleaner) Cleanup(ctx context.Context, id commonids.ResourceGroupId, client *clients.AzureClient, opts options.Options) error {
+func (serviceBusNamespaceBreakPairingCleaner) Cleanup(ctx context.Context, id commonids.ResourceGroupId, client *clients.AzureClient, opts options.Options) error {
 	serviceBusClient := client.ResourceManager.ServiceBus
 	namespacesInResourceGroup, err := serviceBusClient.Namespaces.ListByResourceGroupComplete(ctx, id)
 	if err != nil {
@@ -77,6 +77,12 @@ func (s serviceBusNamespaceBreakPairingCleaner) Cleanup(ctx context.Context, id 
 		}
 	}
 	return nil
+}
+
+func (serviceBusNamespaceBreakPairingCleaner) ResourceTypes() []string {
+	return []string{
+		"Microsoft.ServiceBus/namespaces",
+	}
 }
 
 type serviceBusNamespaceBreakPairingPoller struct {

--- a/dalek/cleaners/resource_groups.go
+++ b/dalek/cleaners/resource_groups.go
@@ -23,4 +23,7 @@ type ResourceGroupCleaner interface {
 
 	// Cleanup performs the cleanup operation for this ResourceGroupCleaner
 	Cleanup(ctx context.Context, id commonids.ResourceGroupId, client *clients.AzureClient, opts options.Options) error
+
+	// ResourceTypes returns the list of Resource Types supported by this ResourceGroupCleaner
+	ResourceTypes() []string
 }

--- a/dalek/cleaners/resource_groups.go
+++ b/dalek/cleaners/resource_groups.go
@@ -13,8 +13,9 @@ var ResourceGroupCleaners = []ResourceGroupCleaner{
 	// would prevent us from doing anything else, so that needs to be first.
 	removeLocksFromResourceGroupCleaner{},
 	removeDataProtectionFromResourceGroupCleaner{},
-	serviceBusNamespaceBreakPairingCleaner{},
+	notificationHubNamespacesCleaner{},
 	paloAltoLocalRulestackCleaner{},
+	serviceBusNamespaceBreakPairingCleaner{},
 }
 
 type ResourceGroupCleaner interface {

--- a/dalek/cleaners/subscriptions.go
+++ b/dalek/cleaners/subscriptions.go
@@ -9,7 +9,6 @@ import (
 )
 
 var SubscriptionCleaners = []SubscriptionCleaner{
-	notificationHubNamespacesCleaner{},
 	deleteStorageSyncSubscriptionCleaner{},
 	deleteResourceGroupsInSubscriptionCleaner{},
 	purgeSoftDeletedManagedHSMsInSubscriptionCleaner{},


### PR DESCRIPTION
We now conditionally run Resource Group cleaners only when there's items within the Resource Group which require cleaning, for expediency purposes

In addition - the Notification Hub Namespace cleaner is now a Resource Group cleaner rather than a Subscription cleaner