### PR TITLE
Add Resource Group prefix filtering to subscription cleaners

### DIFF
--- a/clients/client.go
+++ b/clients/client.go
@@ -166,6 +166,9 @@ func buildResourceManagerClient(ctx context.Context, creds auth.Credentials, env
 	dataProtectionClient, err := dataProtection.NewClientWithBaseURI(environment.ResourceManager, func(c *resourcemanager.Client) {
 		c.Authorizer = resourceManagerAuthorizer
 	})
+	if err != nil {
+		return nil, fmt.Errorf("building Data Protection Client: %+v", err)
+	}
 
 	locksClient, err := managementlocks.NewManagementLocksClientWithBaseURI(environment.ResourceManager)
 	if err != nil {
@@ -224,6 +227,9 @@ func buildResourceManagerClient(ctx context.Context, creds auth.Credentials, env
 	paloAltoClient, err := paloAltoNetworks.NewClientWithBaseURI(environment.ResourceManager, func(c *resourcemanager.Client) {
 		c.Authorizer = resourceManagerAuthorizer
 	})
+	if err != nil {
+		return nil, fmt.Errorf("building Palo Alto Networks Client: %+v", err)
+	}
 
 	resourceGraphClient, err := resourceGraph.NewResourcesClientWithBaseURI(environment.ResourceManager)
 	if err != nil {

--- a/dalek/cleaners/subscriptions_delete_net_app.go
+++ b/dalek/cleaners/subscriptions_delete_net_app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/go-azure-helpers/lang/response"
@@ -47,6 +48,11 @@ func (p deleteNetAppSubscriptionCleaner) Cleanup(ctx context.Context, subscripti
 		accountIdForCapacityPool, err := capacitypools.ParseNetAppAccountID(*account.Id)
 		if err != nil {
 			return err
+		}
+
+		if !strings.HasPrefix(accountIdForCapacityPool.ResourceGroupName, opts.Prefix) {
+			log.Printf("[DEBUG] Not deleting %q as it does not match target RG prefix %q", *accountIdForCapacityPool, opts.Prefix)
+			continue
 		}
 
 		if !opts.ActuallyDelete {

--- a/dalek/cleaners/subscriptions_soft_delete_machine_learning_workspaces.go
+++ b/dalek/cleaners/subscriptions_soft_delete_machine_learning_workspaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/go-azure-helpers/resourcemanager/commonids"
 	"github.com/hashicorp/go-azure-sdk/resource-manager/machinelearningservices/2023-04-01-preview/workspaces"
@@ -31,6 +32,12 @@ func (p purgeSoftDeletedMachineLearningWorkspacesInSubscriptionCleaner) Cleanup(
 		if err != nil {
 			return fmt.Errorf("parsing Machine Learning Workspace ID %q: %+v", *workspace.Id, err)
 		}
+
+		if !strings.HasSuffix(workspaceId.ResourceGroupName, opts.Prefix) {
+			log.Printf("[DEBUG] Not deleting Machine Learning Workspace %q as it does not match target RG prefix %q", *workspaceId, opts.Prefix)
+			continue
+		}
+
 		log.Printf("[DEBUG] Purging Soft-Deleted %s..", *workspaceId)
 		if !opts.ActuallyDelete {
 			log.Printf("[DEBUG] Would have purged soft-deleted Machine Learning Workspace %q..", *workspaceId)

--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Hour)
 	defer cancel()
 	if err := run(ctx, credentials, opts); err != nil {
-		log.Fatalf(err.Error())
+		log.Print(err.Error())
 	}
 }
 


### PR DESCRIPTION
Also fixes:
- Missing error handling in client.go
- changes run exit logging level to allow deferred `cancel()` to execute