### PR TITLE
`cleaners` - don't exit run on PA blocking failure

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ func main() {
 	defer cancel()
 	if err := run(ctx, credentials, opts); err != nil {
 		log.Print(err.Error())
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Also sets an exit code on a received error so the build won't show as successful in CI tooling.

also fixes some typos in error messages.