### PR TITLE
Prevent fail-fast on Resource Manager clean-up

### DIFF
--- a/dalek/resource_manager.go
+++ b/dalek/resource_manager.go
@@ -9,14 +9,14 @@ import (
 	"github.com/tombuildsstuff/azurerm-dalek/dalek/cleaners"
 )
 
-func (d *Dalek) ResourceManager(ctx context.Context) error {
+func (d *Dalek) ResourceManager(ctx context.Context) (errors []error) {
 	subscriptionId := commonids.NewSubscriptionID(d.client.SubscriptionID)
 	for _, cleaner := range cleaners.SubscriptionCleaners {
 		log.Printf("[DEBUG] Running Subscription Cleaner %q in %q", cleaner.Name(), subscriptionId)
 		if err := cleaner.Cleanup(ctx, subscriptionId, d.client, d.opts); err != nil {
-			return fmt.Errorf("running Subscription Cleaner %q in %q: %+v", cleaner.Name(), subscriptionId, err)
+			errors = append(errors, fmt.Errorf("running Subscription Cleaner %q in %q: %+v", cleaner.Name(), subscriptionId, err))
 		}
 	}
 
-	return nil
+	return
 }

--- a/main.go
+++ b/main.go
@@ -54,10 +54,10 @@ func run(ctx context.Context, credentials clients.Credentials, opts options.Opti
 	if errors := client.ResourceManager(ctx); len(errors) != 0 {
 		errList := make([]string, 0)
 		for _, e := range errors {
-			errList = append(errList, "\n"+e.Error())
+			errList = append(errList, e.Error())
 		}
 
-		return fmt.Errorf("processing Resource Manager: %+v", errList)
+		return fmt.Errorf("processing Resource Manager: %+v", strings.Join(errList, "\n"))
 	}
 
 	log.Printf("[DEBUG] Processing Microsoft Graph..")

--- a/main.go
+++ b/main.go
@@ -51,9 +51,15 @@ func run(ctx context.Context, credentials clients.Credentials, opts options.Opti
 
 	client := dalek.NewDalek(sdkClient, opts)
 	log.Printf("[DEBUG] Processing Resource Manager..")
-	if err := client.ResourceManager(ctx); err != nil {
-		return fmt.Errorf("processing Resource Manager: %+v", err)
+	if errors := client.ResourceManager(ctx); len(errors) != 0 {
+		errList := make([]string, 0)
+		for _, e := range errors {
+			errList = append(errList, "\n"+e.Error())
+		}
+
+		return fmt.Errorf("processing Resource Manager: %+v", errList)
 	}
+
 	log.Printf("[DEBUG] Processing Microsoft Graph..")
 	if err := client.MicrosoftGraph(ctx); err != nil {
 		return fmt.Errorf("processing Microsoft Graph: %+v", err)


### PR DESCRIPTION
collect Resource Manager errors and report collectively at the end rather then exiting early